### PR TITLE
Include line numbers for strings like from i18n/en.yaml when extracting

### DIFF
--- a/hugo_gettext/extraction/index.py
+++ b/hugo_gettext/extraction/index.py
@@ -48,14 +48,17 @@ class Extraction:
         # data
         if hg_config.data:
             self.i12ize_data_files()
-        # strings
+        # strings (like i18n/en.yaml)
         if hg_config.do_strings and hg_config.string_file_path:
             src_strings = utils.read_file(hg_config.string_file_path)
-            for _, string in src_strings.items():
+            for key, string in src_strings.items():
+                msgid = string['other']
+                line = msgid.line if isinstance(msgid, utils.StrWithLineInfo) else 0
                 self.default_domain_e.add_entry(hg_config.string_file_path,
-                                                string['other'],
-                                                0,
-                                                string.get('comment', ''))
+                                                msgid,
+                                                line,
+                                                string.get('comment', ''),
+                                                msgctxt=key)
 
     def extract(self, target_dir: str):
         os.makedirs(target_dir, exist_ok=True)


### PR DESCRIPTION
Right now KDE website strings that come from i18n/en.yaml always end up with 0 as the line number. For example, this is an excerpt from documentation-develop-kde-org's PO template output:

```po
#: i18n/en.yaml:0
msgid "Previous"
msgstr ""

#: i18n/en.yaml:0
msgid "Next"
msgstr ""

#: i18n/en.yaml:0
msgid "Read more"
msgstr ""
```

It turns out it's possible to augment PyYAML to include the line number information as a part of the output. By subclassing str to add just one property, other things treat it as a normal string while the extraction process can copy the line number to the POT file.

This PR also includes the key in i18n/en.yaml as context, as I find it actually useful when translating.

After this patch, the output for the same file becomes:

```po
#: i18n/en.yaml:6
msgctxt "ui_pager_prev"
msgid "Previous"
msgstr ""

#: i18n/en.yaml:9
msgctxt "ui_pager_next"
msgid "Next"
msgstr ""

#: i18n/en.yaml:12
msgctxt "ui_read_more"
msgid "Read more"
msgstr ""
```

with the line numbers pointing to the right place (such as [i18n/en.yaml:9](https://invent.kde.org/documentation/develop-kde-org/-/blob/master/i18n/en.yaml#L9)) and the key being included as context.